### PR TITLE
[FLINK-31759][rabbitmq] Update some external connectors to use sql_connector_download_table and connector_artifact shortcode

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content.zh/docs/connectors/datastream/rabbitmq.md
@@ -38,7 +38,7 @@ Flink 自身既没有复用 "RabbitMQ AMQP Java Client" 的代码，也没有将
 
 这个连接器可以访问 [RabbitMQ](http://www.rabbitmq.com/) 的数据流。使用这个连接器，需要在工程里添加下面的依赖：
 
-{{< artifact flink-connector-rabbitmq >}}
+{{< connector_artifact flink-connector-rabbitmq 3.0.0 >}}
 
 {{< py_download_link "rabbitmq" >}}
 

--- a/docs/content/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content/docs/connectors/datastream/rabbitmq.md
@@ -42,7 +42,7 @@ must be aware that this may be subject to conditions declared in the Mozilla Pub
 
 This connector provides access to data streams from [RabbitMQ](http://www.rabbitmq.com/). To use this connector, add the following dependency to your project:
 
-{{< artifact flink-connector-rabbitmq >}}
+{{< connector_artifact flink-connector-rabbitmq 3.0.0 >}}
 
 {{< py_download_link "rabbitmq" >}}
 


### PR DESCRIPTION
This should also backports to v3.0 branch.