### PR TITLE
[FLINK-26907][Connector/RabbitMQ]] RMQSourceITCase failed on azure due to container startup failed

### DIFF
--- a/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
+++ b/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
@@ -88,7 +88,8 @@ public class RMQSourceITCase {
     public static final RabbitMQContainer RMQ_CONTAINER =
             new RabbitMQContainer(DockerImageName.parse(DockerImageVersions.RABBITMQ))
                     .withExposedPorts(RABBITMQ_PORT)
-                    .withLogConsumer(LOG_CONSUMER);
+                    .withLogConsumer(LOG_CONSUMER)
+                    .withStartupAttempts(3);
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

*RMQSourceITCase failed on azure due to ContainerLaunchException: Container startup failed, Increase the number of TestContainer startup attempts*


## Brief change log

  - *Increase the number of TestContainer startup attempts from 1 to 3.*


## Verifying this change

  - *This change is already covered by existing tests*