### PR TITLE
[hotfix] Run push_pr.yml against multiple Flink versions

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   compile_and_test:
+    strategy:
+      matrix:
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.17.0
+      flink_version: ${{ matrix.flink }}


### PR DESCRIPTION
Run push_pr.yml against multiple Flink versions. Now the CI will not run in Flink 1.18.