### PR TITLE
[FLINK-34020][BP v3.0] Bump CI flink version on flink-connector-rabbitmq

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -23,6 +23,14 @@ concurrency:
   cancel-in-progress: true
 jobs:
   compile_and_test:
+    strategy:
+      matrix:
+        flink: [ 1.16.3, 1.17.2 ]
+        jdk: [ '8, 11' ]
+        include:
+          - flink: 1.18.0
+            jdk: '8, 11, 17'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.16.1
+      flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,8 +26,34 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        flink_branches: [{
+          flink: 1.16-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.17-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.18-SNAPSHOT,
+          jdk: '8, 11, 17',
+          branch: main
+        }, {
+          flink: 1.19-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
+          branch: main
+        }, {
+          flink: 1.16.2,
+          branch: v3.0
+        }, {
+          flink: 1.17.1,
+          branch: v3.0
+        }, {
+          flink: 1.18.0,
+          jdk: '8, 11, 17',
+          branch: v3.0
+        }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: ${{ matrix.flink }}
+      flink_version: ${{ matrix.flink_branches.flink }}
+      connector_branch: ${{ matrix.flink_branches.branch }}
+      jdk_version: ${{ matrix.flink_branches.jdk || '8, 11' }}
       run_dependency_convergence: false

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink RabbitMQ Connector
-Copyright 2014-2023 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connector-rabbitmq/pom.xml
+++ b/flink-connector-rabbitmq/pom.xml
@@ -91,4 +91,34 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>run-end-to-end-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>end-to-end-tests</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<configuration>
+									<includes>
+										<include>**/*.*</include>
+									</includes>
+									<systemPropertyVariables>
+										<moduleDir>${project.basedir}</moduleDir>
+									</systemPropertyVariables>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -42,6 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -236,6 +238,8 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
     @Override
     public void open(Configuration config) throws Exception {
         super.open(config);
+        sessionIds = new ArrayList<>(64);
+        sessionIdsPerSnapshot = new ArrayDeque<>();
         try {
             connection = setupConnection();
             channel = setupChannel(connection);

--- a/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/test/DockerImageVersions.java
+++ b/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/test/DockerImageVersions.java
@@ -24,5 +24,5 @@ package org.apache.flink.streaming.connectors.rabbitmq.test;
  */
 public class DockerImageVersions {
 
-    public static final String RABBITMQ = "rabbitmq:3.9.8-management-alpine";
+    public static final String RABBITMQ = "rabbitmq:3.12.12-management-alpine";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@ under the License.
     <properties>
         <flink.version>1.16.0</flink.version>
 
-        <junit5.version>5.8.1</junit5.version>
+        <junit5.version>5.10.1</junit5.version>
         <assertj.version>3.23.1</assertj.version>
-        <testcontainers.version>1.17.2</testcontainers.version>
-        <mockito.version>2.21.0</mockito.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
+        <mockito.version>3.4.6</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
 
         <japicmp.skip>false</japicmp.skip>
@@ -84,10 +84,11 @@ under the License.
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
             <version>${junit5.version}</version>
-            <scope>test</scope>
+            <type>pom</type>
+            <scope>import</scope>
         </dependency>
 
         <dependency>
@@ -256,9 +257,23 @@ under the License.
 
             <!-- For dependency convergence -->
             <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit5.version}</version>
+            </dependency>
+
+            <!-- For dependency convergence -->
+            <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-engine</artifactId>
-                <version>1.8.1</version>
+                <version>1.10.1</version>
+            </dependency>
+
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit5.version}</version>
             </dependency>
 
             <!-- For dependency convergence -->
@@ -266,13 +281,6 @@ under the License.
                 <groupId>com.esotericsoftware.kryo</groupId>
                 <artifactId>kryo</artifactId>
                 <version>2.24.0</version>
-            </dependency>
-
-            <!-- For dependency convergence -->
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit5.version}</version>
             </dependency>
 
             <!-- For dependency convergence -->
@@ -287,6 +295,33 @@ under the License.
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>2.6</version>
+            </dependency>
+
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.objenesis</groupId>
+                <artifactId>objenesis</artifactId>
+                <version>2.6</version>
+            </dependency>
+
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.24.0</version>
+            </dependency>
+
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.4</version>
+            </dependency>
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit5.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
(cherry picked from commit 33d125f591cc5f99e12280fbe2725bd374f7738b)

This also includes syncs `main` to `v3.0` for some dependency versions/convergences
